### PR TITLE
fix: include time in formatted dates

### DIFF
--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -33,7 +33,9 @@ export const formatDistanceToNow = (dateString) => {
 
 export const formatDate = (dateString) => {
   const date = new Date(dateString)
-  return date.toLocaleDateString('en-US', {
+  // Use toLocaleString instead of toLocaleDateString so that time options
+  // like hour and minute are respected across environments.
+  return date.toLocaleString('en-US', {
     year: 'numeric',
     month: 'short',
     day: 'numeric',


### PR DESCRIPTION
## Summary
- ensure formatDate respects time options by using `toLocaleString`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6e938e9f48324adaf22e6e01a40cb